### PR TITLE
[BACK-2290] Small dexcom sharing tweaks

### DIFF
--- a/datasources/consumer.go
+++ b/datasources/consumer.go
@@ -137,19 +137,21 @@ func (p *CDCConsumer) applyPatientDataSourcesUpdate(event CDCEvent) error {
 		return fmt.Errorf("unexpected status code when fetching user data sources %w", err)
 	}
 
-	var updateBody clinics.UpdatePatientDataSourcesJSONRequestBody
+	if len(sources) > 0 {
+		var updateBody clinics.UpdatePatientDataSourcesJSONRequestBody
 
-	for _, source := range sources {
-		updateBody = append(updateBody, event.CreateUpdateBody(*source))
-	}
+		for _, source := range sources {
+			updateBody = append(updateBody, event.CreateUpdateBody(*source))
+		}
 
-	response, err := p.clinics.UpdatePatientDataSourcesWithResponse(ctx, userId, updateBody)
-	if err != nil {
-		return err
-	}
+		response, err := p.clinics.UpdatePatientDataSourcesWithResponse(ctx, userId, updateBody)
+		if err != nil {
+			return err
+		}
 
-	if !(response.StatusCode() == http.StatusOK || response.StatusCode() == http.StatusNotFound) {
-		return fmt.Errorf("unexpected status code when updating patient data sources %v", response.StatusCode())
+		if !(response.StatusCode() == http.StatusOK || response.StatusCode() == http.StatusNotFound) {
+			return fmt.Errorf("unexpected status code when updating patient data sources %v", response.StatusCode())
+		}
 	}
 
 	return nil

--- a/patients/consumer.go
+++ b/patients/consumer.go
@@ -425,8 +425,9 @@ func (p *PatientCDCConsumer) applyInviteUpdate(event PatientCDCEvent) error {
 		return fmt.Errorf("unable to upsert confirmation: %w", err)
 	}
 
-	// Hydrophone returns 403 when there's an existing invite so that's an expected response
-	if response.StatusCode() != http.StatusOK && response.StatusCode() != http.StatusForbidden {
+	// Hydrophone returns 403 when there's an existing invite, or 404 if not found, as in the case of
+	// deleted users, so those are expected responses
+	if response.StatusCode() != http.StatusOK && response.StatusCode() != http.StatusForbidden && response.StatusCode() != http.StatusNotFound {
 		return fmt.Errorf("unexpected status code %v when upserting confirmation", response.StatusCode())
 	}
 

--- a/patients/consumer.go
+++ b/patients/consumer.go
@@ -179,7 +179,8 @@ func (p *PatientCDCConsumer) handleCDCEvent(event PatientCDCEvent) error {
 				return fmt.Errorf("unable to upsert confirmation: %v", err)
 			}
 
-			// Hydrophone returns 403 when there's an existing invite so that's an expected response
+			// Hydrophone returns 403 when there's an existing invite, or 404 if not found, as in the case of
+			// deleted users, so those are expected responses
 			if response.StatusCode() != http.StatusOK && response.StatusCode() != http.StatusForbidden && response.StatusCode() != http.StatusNotFound {
 				return fmt.Errorf("unexpected status code %v when upserting confirmation", response.StatusCode())
 			}

--- a/patients/consumer.go
+++ b/patients/consumer.go
@@ -180,7 +180,7 @@ func (p *PatientCDCConsumer) handleCDCEvent(event PatientCDCEvent) error {
 			}
 
 			// Hydrophone returns 403 when there's an existing invite so that's an expected response
-			if response.StatusCode() != http.StatusOK && response.StatusCode() != http.StatusForbidden {
+			if response.StatusCode() != http.StatusOK && response.StatusCode() != http.StatusForbidden && response.StatusCode() != http.StatusNotFound {
 				return fmt.Errorf("unexpected status code %v when upserting confirmation", response.StatusCode())
 			}
 		}


### PR DESCRIPTION
[BACK-2290]

- Adds a check ensuring data sources length before syncing to clinic patients.  
- No longer throws (and hangs service) if a 404 is returned when a user is not found when performing confirmation signup upserts.  See [hydrophone PR](https://github.com/tidepool-org/hydrophone/pull/115)

[BACK-2290]: https://tidepool.atlassian.net/browse/BACK-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ