### PR TITLE
[BACK-2339] Send dexcom reconnect email for reconnection requests

### DIFF
--- a/datasources/models.go
+++ b/datasources/models.go
@@ -45,7 +45,7 @@ func (p CDCEvent) CreateUpdateBody(source clients.DataSource) clinics.DataSource
 	}
 
 	if source.ModifiedTime != nil {
-		modifiedTimeVal := source.ModifiedTime.Format(time.RFC3339)
+		modifiedTimeVal := clinics.DateTime(source.ModifiedTime.Format(time.RFC3339))
 		patientUpdate.ModifiedTime = &modifiedTimeVal
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.16.0
-	github.com/tidepool-org/clinic/client v0.0.0-20221214172745-738c1cbe291d
+	github.com/tidepool-org/clinic/client v0.0.0-20230113175624-dd3fc2bd9fa6
 	github.com/tidepool-org/go-common v0.10.1-0.20221213195046-9cf40867443c
 	github.com/tidepool-org/hydrophone/client v0.0.0-20221219223301-92bd47a8a11c
 	go.uber.org/fx v1.13.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.16.0
-	github.com/tidepool-org/clinic/client v0.0.0-20230113175624-dd3fc2bd9fa6
+	github.com/tidepool-org/clinic/client v0.0.0-20230113204812-acb7b3592df1
 	github.com/tidepool-org/go-common v0.10.1-0.20221213195046-9cf40867443c
 	github.com/tidepool-org/hydrophone/client v0.0.0-20221219223301-92bd47a8a11c
 	go.uber.org/fx v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tidepool-org/clinic/client v0.0.0-20230113175624-dd3fc2bd9fa6 h1:YltbUl/H1PTRsI0wYIjrmIGyKFsdNQktPliTmfIq3rM=
-github.com/tidepool-org/clinic/client v0.0.0-20230113175624-dd3fc2bd9fa6/go.mod h1:eduhUZw6oOhrtt2C57RGn4rYq9CoCX8ucwDV0PmxSF4=
+github.com/tidepool-org/clinic/client v0.0.0-20230113204812-acb7b3592df1 h1:AnJdcKfvVmfDN5KTfU9PEgd6M4OA0JtJk9E7zhc+/Ss=
+github.com/tidepool-org/clinic/client v0.0.0-20230113204812-acb7b3592df1/go.mod h1:eduhUZw6oOhrtt2C57RGn4rYq9CoCX8ucwDV0PmxSF4=
 github.com/tidepool-org/go-common v0.10.1-0.20221213195046-9cf40867443c h1:wC7BZ0ZN5n1WQwH8yd5S0I4tpymAFcQfAGd/EBKRDVs=
 github.com/tidepool-org/go-common v0.10.1-0.20221213195046-9cf40867443c/go.mod h1:hJ7gk9U6QhIJsVspA8EHN8YuKZuCd/HCP25II+D63w0=
 github.com/tidepool-org/hydrophone/client v0.0.0-20221219223301-92bd47a8a11c h1:7FZ29OLyLOd7OqhfXA6/Ew/3JYjIip9QePG92C3IE2s=

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tidepool-org/clinic/client v0.0.0-20221214172745-738c1cbe291d h1:ocD82O6zvXm0OQOIP79Yri2bShwuktbjevgPqtVCvrE=
-github.com/tidepool-org/clinic/client v0.0.0-20221214172745-738c1cbe291d/go.mod h1:eduhUZw6oOhrtt2C57RGn4rYq9CoCX8ucwDV0PmxSF4=
+github.com/tidepool-org/clinic/client v0.0.0-20230113175624-dd3fc2bd9fa6 h1:YltbUl/H1PTRsI0wYIjrmIGyKFsdNQktPliTmfIq3rM=
+github.com/tidepool-org/clinic/client v0.0.0-20230113175624-dd3fc2bd9fa6/go.mod h1:eduhUZw6oOhrtt2C57RGn4rYq9CoCX8ucwDV0PmxSF4=
 github.com/tidepool-org/go-common v0.10.1-0.20221213195046-9cf40867443c h1:wC7BZ0ZN5n1WQwH8yd5S0I4tpymAFcQfAGd/EBKRDVs=
 github.com/tidepool-org/go-common v0.10.1-0.20221213195046-9cf40867443c/go.mod h1:hJ7gk9U6QhIJsVspA8EHN8YuKZuCd/HCP25II+D63w0=
 github.com/tidepool-org/hydrophone/client v0.0.0-20221219223301-92bd47a8a11c h1:7FZ29OLyLOd7OqhfXA6/Ew/3JYjIip9QePG92C3IE2s=

--- a/patients/models.go
+++ b/patients/models.go
@@ -57,7 +57,7 @@ func (p PatientCDCEvent) IsPatientCreateFromExistingUserEvent() bool {
 func (p PatientCDCEvent) PatientHasPendingDexcomConnection() bool {
 	if p.FullDocument.DataSources != nil {
 		for _, dataSource := range *p.FullDocument.DataSources {
-			if *dataSource.ProviderName == "dexcom" && *dataSource.State == "pending" {
+			if *dataSource.ProviderName == DexcomDataSourceProviderName && *dataSource.State == string(clinics.DataSourceStatePending) {
 				return true
 			}
 		}
@@ -94,7 +94,7 @@ func (p PatientCDCEvent) CreateDataSourceBody(source clients.DataSource) clinics
 	}
 
 	if source.ModifiedTime != nil {
-		modifiedTimeVal := source.ModifiedTime.Format(time.RFC3339)
+		modifiedTimeVal := clinics.DateTime(source.ModifiedTime.Format(time.RFC3339))
 		dataSource.ModifiedTime = &modifiedTimeVal
 	}
 


### PR DESCRIPTION
See [BACK-2339]

- Sets mailer to use the reconnect email template if the patient dexcom data source state is `pendingReconnect`

[BACK-2339]: https://tidepool.atlassian.net/browse/BACK-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ