### PR TITLE
[BACK-2664] Fix a nil pointer in scheduled reports

### DIFF
--- a/redox/consumer_scheduled.go
+++ b/redox/consumer_scheduled.go
@@ -102,11 +102,13 @@ func (s *ScheduledSummaryAndReportsCDCConsumer) unmarshalEvent(value []byte, eve
 func (s *ScheduledSummaryAndReportsCDCConsumer) handleCDCEvent(event cdc.Event[ScheduledSummaryAndReport]) error {
 	if event.FullDocument == nil {
 		s.logger.Infow("skipping event with no full document", "offset", event.Offset)
+		return nil
 	}
 
 	scheduled := event.FullDocument
 	if scheduled.LastMatchedOrder.Meta.IsValid() {
 		s.logger.Infow("skipping event with invalid meta", "offset", event.Offset)
+		return nil
 	}
 
 	// We only expect orders for now


### PR DESCRIPTION
The collection has a TTL index and old documents will be automatically removed. CDC events which delete documents don't have a `fullDocument` attribute which causes a nil pointer panic, because of the missing return statements.