### PR TITLE
[BACK-3478] Only send reports if there is new data

### DIFF
--- a/redox/processor_neworder.go
+++ b/redox/processor_neworder.go
@@ -22,6 +22,7 @@ const (
 	EventTypeNewOrder               = "New"
 	DataModelOrder                  = "Order"
 	MinimumAgeSelfOwnedAccountYears = 13
+	NoteReplacementDuration         = -5 * time.Minute
 )
 
 type NewOrderProcessor interface {
@@ -30,16 +31,16 @@ type NewOrderProcessor interface {
 }
 
 type SummaryAndReportParameters struct {
-	Match               clinics.EHRMatchResponse
-	Order               models.NewOrder
-	DocumentId          string
-	PrecedingDocumentId string
+	Match             clinics.EHRMatchResponse
+	Order             models.NewOrder
+	DocumentId        string
+	PrecedingDocument *PrecedingDocument
 }
 
 func (s SummaryAndReportParameters) ShouldReplacePrecedingReport() bool {
 	if s.Match.Settings.ScheduledReports.OnUploadNoteEventType != nil &&
 		*s.Match.Settings.ScheduledReports.OnUploadNoteEventType == clinics.ScheduledReportsOnUploadNoteEventTypeReplace &&
-		s.PrecedingDocumentId != "" {
+		s.PrecedingDocument != nil && s.PrecedingDocument.CreatedTime.After(time.Now().Add(NoteReplacementDuration)) {
 		return true
 	}
 	return false
@@ -563,9 +564,9 @@ func (o *newOrderProcessor) createReportNote(ctx context.Context, params Summary
 			"order", params.Order.Meta,
 			"clinicId", params.Match.Clinic.Id,
 			"patientId", patient.Id,
-			"precedingDocumentId", params.PrecedingDocumentId,
+			"precedingDocumentId", params.PrecedingDocument.Id.Hex(),
 		)
-		notes, err = CreateReplaceNotes(params.PrecedingDocumentId)
+		notes, err = CreateReplaceNotes(params.PrecedingDocument.Id.Hex())
 		if err != nil {
 			return nil, err
 		}

--- a/redox/processor_scheduled.go
+++ b/redox/processor_scheduled.go
@@ -90,12 +90,10 @@ func (r *scheduledSummaryAndReportProcessor) ProcessOrder(ctx context.Context, s
 	}
 
 	params := SummaryAndReportParameters{
-		Match:      match,
-		Order:      scheduled.DecodedOrder,
-		DocumentId: scheduled.Id.Hex(),
-	}
-	if scheduled.PrecedingDocument != nil {
-		params.PrecedingDocumentId = scheduled.PrecedingDocument.Id.Hex()
+		Match:             match,
+		Order:             scheduled.DecodedOrder,
+		DocumentId:        scheduled.Id.Hex(),
+		PrecedingDocument: scheduled.PrecedingDocument,
 	}
 
 	return r.orderProcessor.SendSummaryAndReport(ctx, params)

--- a/redox/processor_scheduled.go
+++ b/redox/processor_scheduled.go
@@ -78,11 +78,20 @@ func (r *scheduledSummaryAndReportProcessor) ProcessOrder(ctx context.Context, s
 		return nil
 	}
 
-	if !patientHasUploadedDataRecently(*patient) {
-		r.logger.Infow("ignoring scheduled summary and report request because the user doesn't have recent data", "clinicId", clinicId, "userId", scheduled.UserId)
+	cutoffTime := getOrderTime(scheduled.DecodedOrder)
+	if scheduled.PrecedingDocument != nil {
+		// Check that there is new data uploaded after the previous scheduled message if one exists
+		cutoffTime = scheduled.PrecedingDocument.CreatedTime
+	}
+	if !patientHasUploadedDataRecently(*patient, cutoffTime) {
+		r.logger.Infow(
+			"ignoring scheduled summary and report request because the user doesn't have recent data",
+			"clinicId", clinicId,
+			"userId", scheduled.UserId,
+			"cutoffDate", cutoffTime.Format(time.RFC3339),
+		)
 		return nil
 	}
-
 	match := clinics.EHRMatchResponse{
 		Clinic:   *clinic,
 		Patients: &clinics.Patients{*patient},
@@ -141,10 +150,9 @@ func (r *scheduledSummaryAndReportProcessor) getClinicSettings(ctx context.Conte
 	return resp.JSON200, nil
 }
 
-func patientHasUploadedDataRecently(patient clinics.Patient) bool {
-	cutoffDate := time.Now().Add(-recentDataCutoff)
+func patientHasUploadedDataRecently(patient clinics.Patient, cutoffTime time.Time) bool {
 	mostRecentUploadDate := getMostRecentUploadDate(patient)
-	return mostRecentUploadDate.After(cutoffDate)
+	return mostRecentUploadDate.After(cutoffTime)
 }
 
 func getMostRecentUploadDate(patient clinics.Patient) time.Time {
@@ -156,4 +164,14 @@ func getMostRecentUploadDate(patient clinics.Patient) time.Time {
 		mostRecentUpload = *patient.Summary.BgmStats.Dates.LastUploadDate
 	}
 	return mostRecentUpload
+}
+
+func getOrderTime(order models.NewOrder) (result time.Time) {
+	if order.Meta.EventDateTime == nil {
+		return
+	}
+
+	// result will be zero if parsing fails, which is what we want to fallback to
+	result, _ = time.Parse(time.RFC3339, *order.Meta.EventDateTime)
+	return
 }

--- a/redox/processor_scheduled_test.go
+++ b/redox/processor_scheduled_test.go
@@ -17,6 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
+	"math/rand/v2"
 	"net/http"
 	"time"
 )
@@ -143,7 +144,7 @@ var _ = Describe("ScheduledSummaryAndReportProcessor", func() {
 			scheduled.Id = primitive.NewObjectID()
 			scheduled.PrecedingDocument = &redox.PrecedingDocument{
 				Id:          primitive.NewObjectID(),
-				CreatedTime: time.Now().Add(-5 * time.Minute),
+				CreatedTime: time.Now().Add(-4 * time.Minute),
 			}
 
 			Expect(scheduledProcessor.ProcessOrder(context.Background(), scheduled)).To(Succeed())
@@ -273,10 +274,9 @@ var _ = Describe("ScheduledSummaryAndReportProcessor", func() {
 
 		It("Should be false when there's no preceding document and clinic is not configured for replacement", func() {
 			params := redox.SummaryAndReportParameters{
-				Match:               *response,
-				Order:               *order,
-				DocumentId:          "1234567",
-				PrecedingDocumentId: "",
+				Match:      *response,
+				Order:      *order,
+				DocumentId: "1234567",
 			}
 			Expect(params.ShouldReplacePrecedingReport()).To(BeFalse())
 		})
@@ -288,12 +288,15 @@ var _ = Describe("ScheduledSummaryAndReportProcessor", func() {
 				Match:               *response,
 				Order:               *order,
 				DocumentId:          "1234567",
-				PrecedingDocumentId: "0001111",
+				PrecedingDocument: &redox.PrecedingDocument{
+					Id:          primitive.NewObjectID(),
+					CreatedTime: time.Now().Add(-time.Minute),
+				},
 			}
 			Expect(params.ShouldReplacePrecedingReport()).To(BeFalse())
 		})
 
-		It("Should be false true there's is preceding document and clinic is configured for replacement", func() {
+		It("Should be false if there's is preceding document created more than 5 minutes ago and the clinic is configured for replacement", func() {
 			eventType := clinics.ScheduledReportsOnUploadNoteEventTypeReplace
 			response.Settings.ScheduledReports.OnUploadNoteEventType = &eventType
 
@@ -301,7 +304,27 @@ var _ = Describe("ScheduledSummaryAndReportProcessor", func() {
 				Match:               *response,
 				Order:               *order,
 				DocumentId:          "1234567",
-				PrecedingDocumentId: "0001111",
+				PrecedingDocument: &redox.PrecedingDocument{
+					Id:          primitive.NewObjectID(),
+					CreatedTime: time.Now().Add(-time.Minute * 5 - time.Second),
+				},
+			}
+			Expect(params.ShouldReplacePrecedingReport()).To(BeFalse())
+		})
+
+		It("Should be true if there's is preceding document created within the last 5 minutes and the clinic is configured for replacement", func() {
+			eventType := clinics.ScheduledReportsOnUploadNoteEventTypeReplace
+			response.Settings.ScheduledReports.OnUploadNoteEventType = &eventType
+
+			offset := rand.IntN(int((time.Minute * 5 - time.Second * 10).Seconds())) + 1
+			params := redox.SummaryAndReportParameters{
+				Match:               *response,
+				Order:               *order,
+				DocumentId:          "1234567",
+				PrecedingDocument: &redox.PrecedingDocument{
+					Id:          primitive.NewObjectID(),
+					CreatedTime: time.Now().Add(-time.Second * time.Duration(offset)),
+				},
 			}
 			Expect(params.ShouldReplacePrecedingReport()).To(BeTrue())
 		})

--- a/redox/processor_scheduled_test.go
+++ b/redox/processor_scheduled_test.go
@@ -211,10 +211,49 @@ var _ = Describe("ScheduledSummaryAndReportProcessor", func() {
 
 		})
 
-		It("doesn't send any documents if last upload date is more than 14 days ago", func() {
-			beforeCutoff := time.Now().Add(-15 * 24 * time.Hour)
-			patient.Summary.CgmStats.Dates.LastUploadDate = &beforeCutoff
-			patient.Summary.BgmStats.Dates.LastUploadDate = &beforeCutoff
+		It("sends documents if the original order doesn't have event date time", func() {
+			scheduled.DecodedOrder.Meta.EventDateTime = nil
+
+			afterOrderTime := time.Now().Add(-10 * 24 * time.Hour)
+			patient.Summary.CgmStats.Dates.LastUploadDate = &afterOrderTime
+			patient.Summary.BgmStats.Dates.LastUploadDate = &afterOrderTime
+
+			Expect(scheduledProcessor.ProcessOrder(context.Background(), scheduled)).To(Succeed())
+			Expect(redoxClient.Sent).To(HaveLen(2))
+		})
+
+		It("sends documents if the original order's event date time can't be parsed", func() {
+			orderTime := "2099-AA"
+			scheduled.DecodedOrder.Meta.EventDateTime = &orderTime
+
+			afterOrderTime := time.Now().Add(-10 * 24 * time.Hour)
+			patient.Summary.CgmStats.Dates.LastUploadDate = &afterOrderTime
+			patient.Summary.BgmStats.Dates.LastUploadDate = &afterOrderTime
+
+			Expect(scheduledProcessor.ProcessOrder(context.Background(), scheduled)).To(Succeed())
+			Expect(redoxClient.Sent).To(HaveLen(2))
+		})
+
+		It("sends documents if last upload date is after the original order time", func() {
+			orderTime := time.Now().Add(-15 * 24 * time.Hour).UTC().Format(time.RFC3339)
+			scheduled.DecodedOrder.Meta.EventDateTime = &orderTime
+
+			afterOrderTime := time.Now().Add(-10 * 24 * time.Hour)
+			patient.Summary.CgmStats.Dates.LastUploadDate = &afterOrderTime
+			patient.Summary.BgmStats.Dates.LastUploadDate = &afterOrderTime
+
+			Expect(scheduledProcessor.ProcessOrder(context.Background(), scheduled)).To(Succeed())
+			Expect(redoxClient.Sent).To(HaveLen(2))
+		})
+
+		It("doesn't send documents if last upload date is before last scheduled document", func() {
+			scheduled.PrecedingDocument = &redox.PrecedingDocument{
+				Id: primitive.NewObjectID(),
+				CreatedTime: time.Now().Add(-10 * 24 * time.Hour),
+			}
+			beforeLastScheduledDocument := scheduled.PrecedingDocument.CreatedTime.Add(-1 * time.Hour)
+			patient.Summary.CgmStats.Dates.LastUploadDate = &beforeLastScheduledDocument
+			patient.Summary.BgmStats.Dates.LastUploadDate = &beforeLastScheduledDocument
 
 			Expect(scheduledProcessor.ProcessOrder(context.Background(), scheduled)).To(Succeed())
 			Expect(redoxClient.Sent).To(HaveLen(0))
@@ -222,7 +261,11 @@ var _ = Describe("ScheduledSummaryAndReportProcessor", func() {
 
 		It("sends documents if bgm upload date is before the cutoff but cgm after", func() {
 			now := time.Now()
-			beforeCutoff := time.Now().Add(-15 * 24 * time.Hour)
+			scheduled.PrecedingDocument = &redox.PrecedingDocument{
+				Id: primitive.NewObjectID(),
+				CreatedTime: time.Now().Add(-10 * 24 * time.Hour),
+			}
+			beforeCutoff := scheduled.PrecedingDocument.CreatedTime.Add(-1 * time.Hour)
 			patient.Summary.CgmStats.Dates.LastUploadDate = &now
 			patient.Summary.BgmStats.Dates.LastUploadDate = &beforeCutoff
 
@@ -232,7 +275,11 @@ var _ = Describe("ScheduledSummaryAndReportProcessor", func() {
 
 		It("sends documents if cgm upload date is before the cutoff but bgm after", func() {
 			now := time.Now()
-			beforeCutoff := time.Now().Add(-15 * 24 * time.Hour)
+			scheduled.PrecedingDocument = &redox.PrecedingDocument{
+				Id: primitive.NewObjectID(),
+				CreatedTime: time.Now().Add(-10 * 24 * time.Hour),
+			}
+			beforeCutoff := scheduled.PrecedingDocument.CreatedTime.Add(-1 * time.Hour)
 			patient.Summary.CgmStats.Dates.LastUploadDate = &beforeCutoff
 			patient.Summary.BgmStats.Dates.LastUploadDate = &now
 


### PR DESCRIPTION
Only send reports if there is new data uploaded after the last scheduled send or after the original order was received