### PR TITLE
remove platform specific bits from Todd's cascading import

### DIFF
--- a/cdc/init.go
+++ b/cdc/init.go
@@ -2,10 +2,14 @@ package cdc
 
 import (
 	"context"
+	"errors"
+	"log"
+
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
 	"github.com/tidepool-org/go-common/asyncevents"
 	"github.com/tidepool-org/go-common/events"
-	"go.uber.org/fx"
-	"log"
 )
 
 func AttachConsumerGroupHooks(cg events.EventConsumer, lifecycle fx.Lifecycle, shutdowner fx.Shutdowner) {
@@ -27,25 +31,75 @@ func AttachConsumerGroupHooks(cg events.EventConsumer, lifecycle fx.Lifecycle, s
 	})
 }
 
-func AttachSaramaRunnerHooks(runner asyncevents.SaramaEventsRunner, lifecycle fx.Lifecycle, shutdowner fx.Shutdowner) {
-	adapted := asyncevents.NewSaramaRunner(runner)
-	lifecycle.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
-			go func() {
-				if err := adapted.Initialize(); err != nil {
-					log.Printf("unable to initialize runner: %v", err)
-				}
-				if err := adapted.Run(); err != nil {
-					log.Printf("error from runner: %v", err)
-					if err := shutdowner.Shutdown(); err != nil {
-						log.Printf("error shutting down runner: %v", err)
-					}
-				}
-			}()
-			return nil
-		},
-		OnStop: func(ctx context.Context) error {
-			return adapted.Terminate()
-		},
-	})
+type SaramaFxAdapterConfig struct {
+	Consumers  []asyncevents.Runner `group:"runners"`
+	Logger     *zap.SugaredLogger
+	Shutdowner fx.Shutdowner
 }
+
+// SaramaFxAdapter adds fx.Lifecycle and Shutdown support to go-common's
+// asyncevents.NonBlockingStartStopAdapter.
+type SaramaFxAdapter struct {
+	*SaramaFxAdapterConfig
+
+	adapters []*asyncevents.NonBlockingStartStopAdapter
+}
+
+type SaramaFxAdapterParams struct {
+	fx.In
+
+	SaramaFxAdapterConfig
+}
+
+func NewSaramaFxAdapter(p SaramaFxAdapterParams) *SaramaFxAdapter {
+	return &SaramaFxAdapter{
+		SaramaFxAdapterConfig: &p.SaramaFxAdapterConfig,
+	}
+}
+
+// Start implements fx.HookFunc.
+func (f *SaramaFxAdapter) Start(ctx context.Context) error {
+	adapters := []*asyncevents.NonBlockingStartStopAdapter{}
+	for _, consumer := range f.Consumers {
+		adapter := asyncevents.NewNonBlockingStartStopAdapter(consumer, f.onError)
+		if err := adapter.Start(ctx); err != nil {
+			return err
+		}
+		adapters = append(adapters, adapter)
+	}
+	f.adapters = adapters
+	return nil
+}
+
+// onError is passed to asyncevents.NonBlockingStartStopAdapter to be called on an error.
+//
+// Using an fx.Shutdowner, we can then shutdown the service.
+func (f *SaramaFxAdapter) onError(err error) {
+	f.Logger.With("error", err).Info("consumer exited unexpectedly")
+	if err := f.Shutdowner.Shutdown(fx.ExitCode(1)); err != nil {
+		f.Logger.With("error", err).Info("shutting down fx")
+	}
+}
+
+// Start implements fx.HookFunc.
+func (f *SaramaFxAdapter) Stop(ctx context.Context) error {
+	var joinedErrs error
+	for _, adapter := range f.adapters {
+		if err := adapter.Stop(ctx); err != nil {
+			joinedErrs = errors.Join(joinedErrs, err)
+		}
+	}
+	return joinedErrs
+}
+
+var Module = fx.Provide(
+	fx.Annotate(
+		NewSaramaFxAdapter,
+		fx.OnStart(func(ctx context.Context, sfa *SaramaFxAdapter) error {
+			return sfa.Start(ctx)
+		}),
+		fx.OnStop(func(ctx context.Context, sfa *SaramaFxAdapter) error {
+			return sfa.Stop(ctx)
+		}),
+	),
+)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/tidepool-org/clinic/client v0.0.0-20250521172904-b61821ac9973
 	github.com/tidepool-org/clinic/redox_models v0.0.0-20250521172904-b61821ac9973
-	github.com/tidepool-org/go-common v0.12.3-0.20250613120630-656deb326ad3
+	github.com/tidepool-org/go-common v0.12.3-0.20250625233514-f3a3357c3d91
 	github.com/tidepool-org/hydrophone/client v0.0.0-20250317164837-a8cd51fd6677
 	go.mongodb.org/mongo-driver v1.17.3
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/tidepool-org/clinic/client v0.0.0-20250521172904-b61821ac9973 h1:KbPq
 github.com/tidepool-org/clinic/client v0.0.0-20250521172904-b61821ac9973/go.mod h1:r4oWW+WA1IzIcB7Y4q9iun2rcihTVXVVYmB4F9dq6HA=
 github.com/tidepool-org/clinic/redox_models v0.0.0-20250521172904-b61821ac9973 h1:L8bcUPW2VIkN96M1P/PKPaDvnc0j5CXL1I2gxn6nF7A=
 github.com/tidepool-org/clinic/redox_models v0.0.0-20250521172904-b61821ac9973/go.mod h1:bQ9DZxk015RhmGG1tR6jRScP9KxyHvS8tzPbVtr82DE=
-github.com/tidepool-org/go-common v0.12.3-0.20250613120630-656deb326ad3 h1:X4+QkiivmVvkFi8B4GCZryvso4JLoPKkKTfC5nqtT44=
-github.com/tidepool-org/go-common v0.12.3-0.20250613120630-656deb326ad3/go.mod h1:v93bMGDHiHcltQY5s7LYTTEe3u9CiGWqBFKah6C0650=
+github.com/tidepool-org/go-common v0.12.3-0.20250625233514-f3a3357c3d91 h1:zWimBR1JVcUwK+n9DdNNw1HWydTzHQCH3LxkckoLbEA=
+github.com/tidepool-org/go-common v0.12.3-0.20250625233514-f3a3357c3d91/go.mod h1:v93bMGDHiHcltQY5s7LYTTEe3u9CiGWqBFKah6C0650=
 github.com/tidepool-org/hydrophone/client v0.0.0-20250317164837-a8cd51fd6677 h1:P3C1YTvLHu7NFHOeh6NDPo5ieVXcF9a+SY4FTToR8B4=
 github.com/tidepool-org/hydrophone/client v0.0.0-20250317164837-a8cd51fd6677/go.mod h1:gon+x+jAh8DZZ2hD23fBWqrYwOizVSwIBbxEsuXCbZ4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/redox/module.go
+++ b/redox/module.go
@@ -1,10 +1,12 @@
 package redox
 
 import (
-	"github.com/kelseyhightower/envconfig"
-	"github.com/tidepool-org/clinic-worker/report"
-	"go.uber.org/fx"
 	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"go.uber.org/fx"
+
+	"github.com/tidepool-org/clinic-worker/report"
 )
 
 var Module = fx.Provide(

--- a/vendor/github.com/tidepool-org/go-common/asyncevents/startstopadapter.go
+++ b/vendor/github.com/tidepool-org/go-common/asyncevents/startstopadapter.go
@@ -1,0 +1,124 @@
+package asyncevents
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Runner abstracts [SaramaConsumerGroupManager], which is intended to be extended with
+// additional capabilities and behaviors.
+type Runner interface {
+	Run(context.Context) error
+}
+
+// BlockingStartStopAdapter for [SaramaConsumerGroupManager] to use Start and Stop methods.
+//
+// This adapter provides a base for more specific adaptation to adjust behavior to their
+// needs. For example [NonBlockingStartStopAdapter] fits well with Uber's fx.Lifecycle,
+// while this adapter is more adaptable to platform's event.Runner interface.
+type BlockingStartStopAdapter struct {
+	Runner Runner
+
+	cancelMu   sync.Mutex
+	cancelFunc context.CancelFunc
+}
+
+func NewBlockingStartStopAdapter(runner Runner) *BlockingStartStopAdapter {
+	return &BlockingStartStopAdapter{
+		Runner: runner,
+	}
+}
+
+func (a *BlockingStartStopAdapter) Start(ctx context.Context) error {
+	cancelCtx, err := a.init(ctx)
+	if err != nil {
+		return err
+	}
+	return a.Runner.Run(cancelCtx)
+}
+
+func (a *BlockingStartStopAdapter) init(ctx context.Context) (context.Context, error) {
+	a.cancelMu.Lock()
+	defer a.cancelMu.Unlock()
+
+	if a.cancelFunc != nil {
+		return nil, fmt.Errorf("can't start consumer, it's already running")
+	}
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	a.cancelFunc = cancelFunc
+	return cancelCtx, nil
+}
+
+func (a *BlockingStartStopAdapter) Stop(_ context.Context) error {
+	a.cancelMu.Lock()
+	defer a.cancelMu.Unlock()
+
+	if a.cancelFunc == nil {
+		return fmt.Errorf("can't stop consumer, it's not running")
+	}
+
+	a.cancelFunc()
+	a.cancelFunc = nil
+
+	return nil
+}
+
+// NonBlockingStartStopAdapter for [SaramaConsumerGroupManager] for non-blocking Start and
+// Stop methods.
+//
+// To facilitate error reporting during non-blocking operation, a callback can be provided,
+// which if defined, will be called with errors that cause a [SaramaConsumerGroupManager]'s
+// Run method to return. In addition, when the callback is defined, panics from within Run
+// are recovered, converted to errors, and passed to the callback before being discarded.
+type NonBlockingStartStopAdapter struct {
+	*BlockingStartStopAdapter
+
+	onError func(error)
+}
+
+func NewNonBlockingStartStopAdapter(consumer Runner, onError func(error)) *NonBlockingStartStopAdapter {
+	blocking := NewBlockingStartStopAdapter(consumer)
+	return &NonBlockingStartStopAdapter{
+		BlockingStartStopAdapter: blocking,
+		onError:                  onError,
+	}
+}
+
+func (a *NonBlockingStartStopAdapter) Start(ctx context.Context) error {
+	go a.start(ctx)
+	return nil
+}
+
+func (a *NonBlockingStartStopAdapter) start(ctx context.Context) {
+	defer a.maybeRecover()
+
+	if err := a.BlockingStartStopAdapter.Start(ctx); err != nil {
+		if a.onError != nil {
+			a.onError(err)
+		}
+	}
+}
+
+// maybeRecover uses a callback, if defined, to process recovered panics.
+//
+// If the callback isn't defined, the panic will be re-raised.
+func (a *NonBlockingStartStopAdapter) maybeRecover() {
+	if r := recover(); r != nil {
+		if a.onError != nil {
+			a.onError(a.wrapPanic(r))
+		} else {
+			panic(r)
+		}
+	}
+}
+
+// wrapPanic converts a non-error value to an error for passing to an on-error callback.
+//
+// Existing error values are wrapped, to allow later unwrapping.
+func (a *NonBlockingStartStopAdapter) wrapPanic(r any) error {
+	if err, ok := r.(error); ok {
+		return fmt.Errorf("consumer panicked: %w", err)
+	}
+	return fmt.Errorf("consumer panicked: %s", r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -207,7 +207,7 @@ github.com/tidepool-org/clinic/client
 # github.com/tidepool-org/clinic/redox_models v0.0.0-20250521172904-b61821ac9973
 ## explicit; go 1.22
 github.com/tidepool-org/clinic/redox_models
-# github.com/tidepool-org/go-common v0.12.3-0.20250613120630-656deb326ad3
+# github.com/tidepool-org/go-common v0.12.3-0.20250625233514-f3a3357c3d91
 ## explicit; go 1.24.1
 github.com/tidepool-org/go-common/asyncevents
 github.com/tidepool-org/go-common/clients


### PR DESCRIPTION
See also: https://github.com/tidepool-org/go-common/pull/79 on which this builds.

- don't use SaramaRunner and SaramaRunnerConfig

  They were intended to mesh with platform abstractions and configuration. They don't generalize well to clinic-worker's needs.

- add an fx-specific adapter for clinic-worker

  This makes use of a newly written non-blocking adapter added to go-common that better generalizes to fx's lifecycle management.

  It looks like a big expansion of code, but that's only because it's doing some of what was hidden by SaramaRunner previously.

- modify to use go-common's asyncevents.CascadingSaramaEventsManager

  This freshly re-worked abstraction should service Care Partner Alerts (it's original intent) and other future users equally well.