### PR TITLE
another take on observations

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -103,14 +103,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tidepool-org/clinic/client v0.0.0-20250609170750-6b55d8d08796 h1:2rLpMH6ISjHIFiPRhd8ESqQg/WKMj9JGZTIIrkUJbLg=
-github.com/tidepool-org/clinic/client v0.0.0-20250609170750-6b55d8d08796/go.mod h1:F13LyaGiR5Ua7+1B8MjbPEW+jqcnFm+5YqsQPv+kmdE=
 github.com/tidepool-org/clinic/client v0.0.0-20250708104415-7542acfbda77 h1:qe4x86Tn9GTczxR12V2vyRAUJr0yCk8Dms142/zLcSA=
 github.com/tidepool-org/clinic/client v0.0.0-20250708104415-7542acfbda77/go.mod h1:F13LyaGiR5Ua7+1B8MjbPEW+jqcnFm+5YqsQPv+kmdE=
 github.com/tidepool-org/clinic/redox_models v0.0.0-20250609170750-6b55d8d08796 h1:TE0weNP/EexzMc+60rFFZjyiEe3flghMOUNUjs3afw0=
 github.com/tidepool-org/clinic/redox_models v0.0.0-20250609170750-6b55d8d08796/go.mod h1:bQ9DZxk015RhmGG1tR6jRScP9KxyHvS8tzPbVtr82DE=
-github.com/tidepool-org/go-common v0.12.3-0.20250605042015-03f64bdd8a80 h1:P4jQHY+1lMK4hZl/8dZt2c0ZOJsFmq2fU8mv5yAJ/OI=
-github.com/tidepool-org/go-common v0.12.3-0.20250605042015-03f64bdd8a80/go.mod h1:v93bMGDHiHcltQY5s7LYTTEe3u9CiGWqBFKah6C0650=
 github.com/tidepool-org/go-common v0.12.3-0.20250625144959-43ca6d0e941d h1:6AYoMi+V6t4JjBuSSD1ra3JrOQk2XMjSVCkUWVLM2Go=
 github.com/tidepool-org/go-common v0.12.3-0.20250625144959-43ca6d0e941d/go.mod h1:v93bMGDHiHcltQY5s7LYTTEe3u9CiGWqBFKah6C0650=
 github.com/tidepool-org/hydrophone/client v0.0.0-20250317164837-a8cd51fd6677 h1:P3C1YTvLHu7NFHOeh6NDPo5ieVXcF9a+SY4FTToR8B4=

--- a/redox/response_flowsheet.go
+++ b/redox/response_flowsheet.go
@@ -167,52 +167,66 @@ func PopulateCGMObservations(stats *clinics.CgmStatsV1, settings FlowsheetSettin
 		timeInVeryHigh = period.TimeInVeryHighPercent
 	}
 
-	observations := []*Observation{
-		{"REPORTING_PERIOD_START_CGM", formatTime(periodStart), "DateTime", nil, reportingTime, "CGM Reporting Period Start"},
-		{"REPORTING_PERIOD_END_CGM", formatTime(periodEnd), "DateTime", nil, reportingTime, "CGM Reporting Period End"},
-		{"REPORTING_PERIOD_START_CGM_DATA", formatTime(firstData), "DateTime", nil, reportingTime, "CGM Reporting Period Start Date of actual Data"},
-		{"TIME_ABOVE_RANGE_VERY_HIGH_CGM", formatFloat(unitIntervalToPercent(timeInVeryHigh)), "Numeric", &unitsPercentage, reportingTime, "CGM Level 2 Hyperglycemia: Time above range (TAR-VH): % of readings and time >250 mg/dL (>13.9 mmol/L)"},
-		{"TIME_ABOVE_RANGE_HIGH_CGM", formatFloat(unitIntervalToPercent(timeInHigh)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Level 1 Hyperglycemia: Time above range (TAR-H): % of readings and time 181–250 mg/dL (10.1–13.9 mmol/L)"},
-		{"TIME_IN_RANGE_CGM", formatFloat(unitIntervalToPercent(timeInTarget)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Range: Time in range (TIR): % of readings and time 70–180 mg/dL (3.9–10.0 mmol/L)"},
-		{"TIME_BELOW_RANGE_LOW_CGM", formatFloat(unitIntervalToPercent(timeInLow)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Level 1 Hypoglycemia: Time below range (TBR-L): % of readings and time 54–69 mg/dL (3.0–3.8 mmol/L)"},
-		{"TIME_BELOW_RANGE_VERY_LOW_CGM", formatFloat(unitIntervalToPercent(timeInVeryLow)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Level 2 Hypoglycemia: <Time below range (TBR-VL): % of readings and time <54 mg/dL (<3.0 mmol/L)"},
-		{"GLUCOSE_MANAGEMENT_INDICATOR", formatFloat(gmi), "Numeric", nil, reportingTime, "CGM Glucose Management Indicator during reporting period"},
-		{"AVERAGE_CGM", formatFloat(averageGlucose), "Numeric", &destGlucoseUnits, reportingTime, "CGM Average Glucose during reporting period"},
-		{"STANDARD_DEVIATION_CGM", formatFloat(cgmStdDev), "Numeric", &destGlucoseUnits, reportingTime, "The standard deviation of CGM measurements during the reporting period"},
-		{"COEFFICIENT_OF_VARIATION_CGM", formatFloat(cgmCoeffVar), "Numeric", nil, reportingTime, "The coefficient of variation (standard deviation * 100 / mean) of CGM measurements during the reporting period"},
-		{"ACTIVE_WEAR_TIME_CGM", formatFloat(unitIntervalToPercent(cgmUsePercent)), "Numeric", &unitsPercentage, reportingTime, "Percentage of time CGM worn during reporting period"},
-		{"DAYS_WITH_DATA_CGM", formatInt(cgmDaysWithData), "Numeric", &unitsDay, reportingTime, "Number of days with at least one CGM datum during the reporting period"},
-		{"HOURS_WITH_DATA_CGM", formatInt(cgmHoursWithData), "Numeric", &unitsHour, reportingTime, "Number of hours with at least one CGM datum during the reporting period"},
-	}
-
-	observationsMap := map[string]*Observation{}
-	for _, observation := range observations {
-		observationsMap[observation.Code] = observation
+	observations := map[string]*Observation{
+		"REPORTING_PERIOD_START_CGM":      {"REPORTING_PERIOD_START_CGM", formatTime(periodStart), "DateTime", nil, reportingTime, "CGM Reporting Period Start"},
+		"REPORTING_PERIOD_END_CGM":        {"REPORTING_PERIOD_END_CGM", formatTime(periodEnd), "DateTime", nil, reportingTime, "CGM Reporting Period End"},
+		"REPORTING_PERIOD_START_CGM_DATA": {"REPORTING_PERIOD_START_CGM_DATA", formatTime(firstData), "DateTime", nil, reportingTime, "CGM Reporting Period Start Date of actual Data"},
+		"TIME_ABOVE_RANGE_VERY_HIGH_CGM":  {"TIME_ABOVE_RANGE_VERY_HIGH_CGM", formatFloat(unitIntervalToPercent(timeInVeryHigh)), "Numeric", &unitsPercentage, reportingTime, "CGM Level 2 Hyperglycemia: Time above range (TAR-VH): % of readings and time >250 mg/dL (>13.9 mmol/L)"},
+		"TIME_ABOVE_RANGE_HIGH_CGM":       {"TIME_ABOVE_RANGE_HIGH_CGM", formatFloat(unitIntervalToPercent(timeInHigh)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Level 1 Hyperglycemia: Time above range (TAR-H): % of readings and time 181–250 mg/dL (10.1–13.9 mmol/L)"},
+		"TIME_IN_RANGE_CGM":               {"TIME_IN_RANGE_CGM", formatFloat(unitIntervalToPercent(timeInTarget)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Range: Time in range (TIR): % of readings and time 70–180 mg/dL (3.9–10.0 mmol/L)"},
+		"TIME_BELOW_RANGE_LOW_CGM":        {"TIME_BELOW_RANGE_LOW_CGM", formatFloat(unitIntervalToPercent(timeInLow)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Level 1 Hypoglycemia: Time below range (TBR-L): % of readings and time 54–69 mg/dL (3.0–3.8 mmol/L)"},
+		"TIME_BELOW_RANGE_VERY_LOW_CGM":   {"TIME_BELOW_RANGE_VERY_LOW_CGM", formatFloat(unitIntervalToPercent(timeInVeryLow)), "Numeric", &unitsPercentage, reportingTime, "CGM Time in Level 2 Hypoglycemia: <Time below range (TBR-VL): % of readings and time <54 mg/dL (<3.0 mmol/L)"},
+		"GLUCOSE_MANAGEMENT_INDICATOR":    {"GLUCOSE_MANAGEMENT_INDICATOR", formatFloat(gmi), "Numeric", nil, reportingTime, "CGM Glucose Management Indicator during reporting period"},
+		"AVERAGE_CGM":                     {"AVERAGE_CGM", formatFloat(averageGlucose), "Numeric", &destGlucoseUnits, reportingTime, "CGM Average Glucose during reporting period"},
+		"STANDARD_DEVIATION_CGM":          {"STANDARD_DEVIATION_CGM", formatFloat(cgmStdDev), "Numeric", &destGlucoseUnits, reportingTime, "The standard deviation of CGM measurements during the reporting period"},
+		"COEFFICIENT_OF_VARIATION_CGM":    {"COEFFICIENT_OF_VARIATION_CGM", formatFloat(cgmCoeffVar), "Numeric", nil, reportingTime, "The coefficient of variation (standard deviation * 100 / mean) of CGM measurements during the reporting period"},
+		"ACTIVE_WEAR_TIME_CGM":            {"ACTIVE_WEAR_TIME_CGM", formatFloat(unitIntervalToPercent(cgmUsePercent)), "Numeric", &unitsPercentage, reportingTime, "Percentage of time CGM worn during reporting period"},
+		"DAYS_WITH_DATA_CGM":              {"DAYS_WITH_DATA_CGM", formatInt(cgmDaysWithData), "Numeric", &unitsDay, reportingTime, "Number of days with at least one CGM datum during the reporting period"},
+		"HOURS_WITH_DATA_CGM":             {"HOURS_WITH_DATA_CGM", formatInt(cgmHoursWithData), "Numeric", &unitsHour, reportingTime, "Number of hours with at least one CGM datum during the reporting period"},
 	}
 
 	// For clinics flagged as icode, replace certain values with alternative formatting, as defined in BACK-3476
 	if settings.ICode {
-		observationsMap["COEFFICIENT_OF_VARIATION_CGM"].Value = formatFloatWithPrecision(unitIntervalToPercent(cgmCoeffVar), 1)
-		observationsMap["COEFFICIENT_OF_VARIATION_CGM"].Units = &unitsPercentage
+		observations["COEFFICIENT_OF_VARIATION_CGM"].Value = formatFloatWithPrecision(unitIntervalToPercent(cgmCoeffVar), 1)
+		observations["COEFFICIENT_OF_VARIATION_CGM"].Units = &unitsPercentage
 
 		// ICode2 defines whole-number precision for average glucose, this is only accurate enough for mg/dl
 		if strings.ToLower(settings.PreferredBGUnits) == "mg/dl" {
-			observationsMap["AVERAGE_CGM"].Value = formatFloatConditionalPrecision(averageGlucose)
+			observations["AVERAGE_CGM"].Value = formatFloatConditionalPrecision(averageGlucose)
 		} else {
-			observationsMap["AVERAGE_CGM"].Value = formatFloatWithPrecision(averageGlucose, 1)
+			observations["AVERAGE_CGM"].Value = formatFloatWithPrecision(averageGlucose, 1)
 		}
 
-		observationsMap["GLUCOSE_MANAGEMENT_INDICATOR"].Value = formatFloatWithPrecision(gmi, 1)
-		observationsMap["ACTIVE_WEAR_TIME_CGM"].Value = formatFloatWithPrecision(unitIntervalToPercent(cgmUsePercent), 2)
-		observationsMap["STANDARD_DEVIATION_CGM"].Value = formatFloatWithPrecision(cgmStdDev, 1)
-		observationsMap["TIME_BELOW_RANGE_VERY_LOW_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryLow))
-		observationsMap["TIME_BELOW_RANGE_LOW_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInLow))
-		observationsMap["TIME_IN_RANGE_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInTarget))
-		observationsMap["TIME_ABOVE_RANGE_HIGH_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInHigh))
-		observationsMap["TIME_ABOVE_RANGE_VERY_HIGH_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryHigh))
+		observations["GLUCOSE_MANAGEMENT_INDICATOR"].Value = formatFloatWithPrecision(gmi, 1)
+		observations["ACTIVE_WEAR_TIME_CGM"].Value = formatFloatWithPrecision(unitIntervalToPercent(cgmUsePercent), 2)
+		observations["STANDARD_DEVIATION_CGM"].Value = formatFloatWithPrecision(cgmStdDev, 1)
+		observations["TIME_BELOW_RANGE_VERY_LOW_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryLow))
+		observations["TIME_BELOW_RANGE_LOW_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInLow))
+		observations["TIME_IN_RANGE_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInTarget))
+		observations["TIME_ABOVE_RANGE_HIGH_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInHigh))
+		observations["TIME_ABOVE_RANGE_VERY_HIGH_CGM"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryHigh))
 	}
 
-	for _, observation := range observations {
+	observationsOrder := []string{
+		"REPORTING_PERIOD_START_CGM",
+		"REPORTING_PERIOD_END_CGM",
+		"REPORTING_PERIOD_START_CGM_DATA",
+		"TIME_ABOVE_RANGE_VERY_HIGH_CGM",
+		"TIME_ABOVE_RANGE_HIGH_CGM",
+		"TIME_IN_RANGE_CGM",
+		"TIME_BELOW_RANGE_LOW_CGM",
+		"TIME_BELOW_RANGE_VERY_LOW_CGM",
+		"GLUCOSE_MANAGEMENT_INDICATOR",
+		"AVERAGE_CGM",
+		"STANDARD_DEVIATION_CGM",
+		"COEFFICIENT_OF_VARIATION_CGM",
+		"ACTIVE_WEAR_TIME_CGM",
+		"DAYS_WITH_DATA_CGM",
+		"HOURS_WITH_DATA_CGM",
+	}
+
+	for _, key := range observationsOrder {
+		observation := observations[key]
 		if observation.Value != missingValue {
 			AppendObservation(f, observation)
 		}
@@ -300,57 +314,74 @@ func PopulateBGMObservations(stats *clinics.BgmStatsV1, settings FlowsheetSettin
 		timeInVeryHighPercent = period.TimeInVeryHighPercent
 	}
 
-	observations := []*Observation{
-		{"REPORTING_PERIOD_START_SMBG", formatTime(periodStart), "DateTime", nil, reportingTime, "SMBG Reporting Period Start"},
-		{"REPORTING_PERIOD_END_SMBG", formatTime(periodEnd), "DateTime", nil, reportingTime, "SMBG Reporting Period End"},
-		{"REPORTING_PERIOD_START_SMBG_DATA", formatTime(firstData), "DateTime", nil, reportingTime, "SMBG Reporting Period Start Date of actual Data"},
-		{"TIME_ABOVE_RANGE_VERY_HIGH_SMBG", formatFloat(unitIntervalToPercent(timeInVeryHighPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings > 250 mg/dL (>13.9 mmol/L)"},
-		{"TIME_ABOVE_RANGE_HIGH_SMBG", formatFloat(unitIntervalToPercent(timeInHighPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings between 181–250 mg/dL (10.1–13.9 mmol/L)"},
-		{"TIME_IN_RANGE_SMBG", formatFloat(unitIntervalToPercent(timeInTargetPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings between 70–180 mg/dL (3.9–10.0 mmol/L)"},
-		{"TIME_BELOW_RANGE_LOW_SMBG", formatFloat(unitIntervalToPercent(timeInLowPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings between 54–69 mg/dL (3.0–3.8 mmol/L)"},
-		{"TIME_BELOW_RANGE_VERY_LOW_SMBG", formatFloat(unitIntervalToPercent(timeInVeryLowPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings < 54 mg/dL (<3.0 mmol/L)"},
-		{"READINGS_ABOVE_RANGE_VERY_HIGH_SMBG", formatInt(timeInVeryHighRecords), "Numeric", nil, reportingTime, "SMBG Level 2 Hyperglycemia: Number of readings above range (TAR-VH) time >250 mg/dL (>13.9 mmol/L) during reporting period"},
-		{"READINGS_BELOW_RANGE_VERY_LOW_SMBG", formatInt(timeInVeryLowRecords), "Numeric", nil, reportingTime, "SMBG Level 2 Hypoglycemia Events: Number of readings <54 mg/dL (<3.0 mmol/L) during reporting period"},
-		{"MAX_SMBG", formatFloat(maxGlucose), "Numeric", &destGlucoseUnits, reportingTime, "Maximum blood glucose reading over the time period"},
-		{"MIN_SMBG", formatFloat(minGlucose), "Numeric", &destGlucoseUnits, reportingTime, "Minimum blood glucose reading over the time period"},
-		{"AVERAGE_SMBG", formatFloat(averageGlucose), "Numeric", &destGlucoseUnits, reportingTime, "SMBG Average Glucose during reporting period"},
-		{"STANDARD_DEVIATION_SMBG", formatFloat(bgmStdDev), "Numeric", &destGlucoseUnits, reportingTime, "The standard deviation of SMBG measurements during the reporting period"},
-		{"COEFFICIENT_OF_VARIATION_SMBG", formatFloat(bgmCoeffVar), "Numeric", nil, reportingTime, "The coefficient of variation (standard deviation * 100 / mean) of SMBG measurements during the reporting period"},
-		{"TOTAL_READING_COUNT_SMBG", formatInt(bgmTotalRecords), "Numeric", nil, reportingTime, "The total number of SMBG readings taken during the SMBG Reporting Period"},
-		{"CHECK_RATE_READINGS_DAY_SMBG", formatFloat(averageDailyRecords), "Numeric", nil, reportingTime, "Average Numeric of SMBG readings per day during reporting period"},
-		{"DAYS_WITH_DATA_SMBG", formatInt(bgmDaysWithData), "Numeric", &unitsDay, reportingTime, "The total number of days with at least 1 SMBG reading over the reporting period"},
-	}
-
-	observationsMap := map[string]*Observation{}
-	for _, observation := range observations {
-		observationsMap[observation.Code] = observation
+	observations := map[string]*Observation{
+		"REPORTING_PERIOD_START_SMBG":         {"REPORTING_PERIOD_START_SMBG", formatTime(periodStart), "DateTime", nil, reportingTime, "SMBG Reporting Period Start"},
+		"REPORTING_PERIOD_END_SMBG":           {"REPORTING_PERIOD_END_SMBG", formatTime(periodEnd), "DateTime", nil, reportingTime, "SMBG Reporting Period End"},
+		"REPORTING_PERIOD_START_SMBG_DATA":    {"REPORTING_PERIOD_START_SMBG_DATA", formatTime(firstData), "DateTime", nil, reportingTime, "SMBG Reporting Period Start Date of actual Data"},
+		"TIME_ABOVE_RANGE_VERY_HIGH_SMBG":     {"TIME_ABOVE_RANGE_VERY_HIGH_SMBG", formatFloat(unitIntervalToPercent(timeInVeryHighPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings > 250 mg/dL (>13.9 mmol/L)"},
+		"TIME_ABOVE_RANGE_HIGH_SMBG":          {"TIME_ABOVE_RANGE_HIGH_SMBG", formatFloat(unitIntervalToPercent(timeInHighPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings between 181–250 mg/dL (10.1–13.9 mmol/L)"},
+		"TIME_IN_RANGE_SMBG":                  {"TIME_IN_RANGE_SMBG", formatFloat(unitIntervalToPercent(timeInTargetPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings between 70–180 mg/dL (3.9–10.0 mmol/L)"},
+		"TIME_BELOW_RANGE_LOW_SMBG":           {"TIME_BELOW_RANGE_LOW_SMBG", formatFloat(unitIntervalToPercent(timeInLowPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings between 54–69 mg/dL (3.0–3.8 mmol/L)"},
+		"TIME_BELOW_RANGE_VERY_LOW_SMBG":      {"TIME_BELOW_RANGE_VERY_LOW_SMBG", formatFloat(unitIntervalToPercent(timeInVeryLowPercent)), "Numeric", &unitsPercentage, reportingTime, "% of readings < 54 mg/dL (<3.0 mmol/L)"},
+		"READINGS_ABOVE_RANGE_VERY_HIGH_SMBG": {"READINGS_ABOVE_RANGE_VERY_HIGH_SMBG", formatInt(timeInVeryHighRecords), "Numeric", nil, reportingTime, "SMBG Level 2 Hyperglycemia: Number of readings above range (TAR-VH) time >250 mg/dL (>13.9 mmol/L) during reporting period"},
+		"READINGS_BELOW_RANGE_VERY_LOW_SMBG":  {"READINGS_BELOW_RANGE_VERY_LOW_SMBG", formatInt(timeInVeryLowRecords), "Numeric", nil, reportingTime, "SMBG Level 2 Hypoglycemia Events: Number of readings <54 mg/dL (<3.0 mmol/L) during reporting period"},
+		"MAX_SMBG":                            {"MAX_SMBG", formatFloat(maxGlucose), "Numeric", &destGlucoseUnits, reportingTime, "Maximum blood glucose reading over the time period"},
+		"MIN_SMBG":                            {"MIN_SMBG", formatFloat(minGlucose), "Numeric", &destGlucoseUnits, reportingTime, "Minimum blood glucose reading over the time period"},
+		"AVERAGE_SMBG":                        {"AVERAGE_SMBG", formatFloat(averageGlucose), "Numeric", &destGlucoseUnits, reportingTime, "SMBG Average Glucose during reporting period"},
+		"STANDARD_DEVIATION_SMBG":             {"STANDARD_DEVIATION_SMBG", formatFloat(bgmStdDev), "Numeric", &destGlucoseUnits, reportingTime, "The standard deviation of SMBG measurements during the reporting period"},
+		"COEFFICIENT_OF_VARIATION_SMBG":       {"COEFFICIENT_OF_VARIATION_SMBG", formatFloat(bgmCoeffVar), "Numeric", nil, reportingTime, "The coefficient of variation (standard deviation * 100 / mean) of SMBG measurements during the reporting period"},
+		"TOTAL_READING_COUNT_SMBG":            {"TOTAL_READING_COUNT_SMBG", formatInt(bgmTotalRecords), "Numeric", nil, reportingTime, "The total number of SMBG readings taken during the SMBG Reporting Period"},
+		"CHECK_RATE_READINGS_DAY_SMBG":        {"CHECK_RATE_READINGS_DAY_SMBG", formatFloat(averageDailyRecords), "Numeric", nil, reportingTime, "Average Numeric of SMBG readings per day during reporting period"},
+		"DAYS_WITH_DATA_SMBG":                 {"DAYS_WITH_DATA_SMBG", formatInt(bgmDaysWithData), "Numeric", &unitsDay, reportingTime, "The total number of days with at least 1 SMBG reading over the reporting period"},
 	}
 
 	// For clinics flagged as icode, replace certain values with alternative formatting, as defined in BACK-3476
 	if settings.ICode {
-		observationsMap["COEFFICIENT_OF_VARIATION_SMBG"].Value = formatFloatWithPrecision(unitIntervalToPercent(bgmCoeffVar), 1)
-		observationsMap["COEFFICIENT_OF_VARIATION_SMBG"].Units = &unitsPercentage
+		observations["COEFFICIENT_OF_VARIATION_SMBG"].Value = formatFloatWithPrecision(unitIntervalToPercent(bgmCoeffVar), 1)
+		observations["COEFFICIENT_OF_VARIATION_SMBG"].Units = &unitsPercentage
 
 		// ICode2 defines whole-number precision for glucose, this is only accurate enough for mg/dl
 		if strings.ToLower(settings.PreferredBGUnits) == "mg/dl" {
-			observationsMap["AVERAGE_SMBG"].Value = formatFloatConditionalPrecision(averageGlucose)
-			observationsMap["MIN_SMBG"].Value = formatFloatConditionalPrecision(minGlucose)
-			observationsMap["MAX_SMBG"].Value = formatFloatConditionalPrecision(maxGlucose)
+			observations["AVERAGE_SMBG"].Value = formatFloatConditionalPrecision(averageGlucose)
+			observations["MIN_SMBG"].Value = formatFloatConditionalPrecision(minGlucose)
+			observations["MAX_SMBG"].Value = formatFloatConditionalPrecision(maxGlucose)
 		} else {
-			observationsMap["AVERAGE_SMBG"].Value = formatFloatWithPrecision(averageGlucose, 1)
-			observationsMap["MIN_SMBG"].Value = formatFloatWithPrecision(minGlucose, 1)
-			observationsMap["MAX_SMBG"].Value = formatFloatWithPrecision(maxGlucose, 1)
+			observations["AVERAGE_SMBG"].Value = formatFloatWithPrecision(averageGlucose, 1)
+			observations["MIN_SMBG"].Value = formatFloatWithPrecision(minGlucose, 1)
+			observations["MAX_SMBG"].Value = formatFloatWithPrecision(maxGlucose, 1)
 		}
 
-		observationsMap["STANDARD_DEVIATION_SMBG"].Value = formatFloatWithPrecision(bgmStdDev, 1)
-		observationsMap["TIME_BELOW_RANGE_VERY_LOW_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryLowPercent))
-		observationsMap["TIME_BELOW_RANGE_LOW_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInLowPercent))
-		observationsMap["TIME_IN_RANGE_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInTargetPercent))
-		observationsMap["TIME_ABOVE_RANGE_HIGH_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInHighPercent))
-		observationsMap["TIME_ABOVE_RANGE_VERY_HIGH_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryHighPercent))
+		observations["STANDARD_DEVIATION_SMBG"].Value = formatFloatWithPrecision(bgmStdDev, 1)
+		observations["TIME_BELOW_RANGE_VERY_LOW_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryLowPercent))
+		observations["TIME_BELOW_RANGE_LOW_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInLowPercent))
+		observations["TIME_IN_RANGE_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInTargetPercent))
+		observations["TIME_ABOVE_RANGE_HIGH_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInHighPercent))
+		observations["TIME_ABOVE_RANGE_VERY_HIGH_SMBG"].Value = formatFloatConditionalPrecision(unitIntervalToPercent(timeInVeryHighPercent))
 	}
 
-	for _, observation := range observations {
+	observationOrder := []string{
+		"REPORTING_PERIOD_START_SMBG",
+		"REPORTING_PERIOD_END_SMBG",
+		"REPORTING_PERIOD_START_SMBG_DATA",
+		"TIME_ABOVE_RANGE_VERY_HIGH_SMBG",
+		"TIME_ABOVE_RANGE_HIGH_SMBG",
+		"TIME_IN_RANGE_SMBG",
+		"TIME_BELOW_RANGE_LOW_SMBG",
+		"TIME_BELOW_RANGE_VERY_LOW_SMBG",
+		"READINGS_ABOVE_RANGE_VERY_HIGH_SMBG",
+		"READINGS_BELOW_RANGE_VERY_LOW_SMBG",
+		"MAX_SMBG",
+		"MIN_SMBG",
+		"AVERAGE_SMBG",
+		"STANDARD_DEVIATION_SMBG",
+		"COEFFICIENT_OF_VARIATION_SMBG",
+		"TOTAL_READING_COUNT_SMBG",
+		"CHECK_RATE_READINGS_DAY_SMBG",
+		"DAYS_WITH_DATA_SMBG",
+	}
+
+	for _, key := range observationOrder {
+		observation := observations[key]
 		if observation.Value != missingValue {
 			AppendObservation(f, observation)
 		}

--- a/redox/response_flowsheet_test.go
+++ b/redox/response_flowsheet_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
+
 	"github.com/tidepool-org/clinic-worker/test"
 	api "github.com/tidepool-org/clinic/client"
 	models "github.com/tidepool-org/clinic/redox_models"


### PR DESCRIPTION
A food for though tweak on this change. This way we don't need to have separate map and slices.

The difference between the tests is just that HaveExactElements maintains order, while ContainsElements doesn't. Both will error if anything is extra or is missing, and as far as I can tell, the order isn't important.

BACK-3651