### PR TITLE
Accept 200 response when deleting restricted tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/tidepool-org/clinic/client v0.0.0-20250620124207-97640792dd28
 	github.com/tidepool-org/clinic/redox_models v0.0.0-20250604035007-1aa5b79109b4
-	github.com/tidepool-org/go-common v0.12.3-0.20250604040229-ade89b59e5db
+	github.com/tidepool-org/go-common v0.12.3-0.20250714145502-f6b9f7ad36fe
 	github.com/tidepool-org/hydrophone/client v0.0.0-20250317164837-a8cd51fd6677
 	go.mongodb.org/mongo-driver v1.17.3
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/tidepool-org/clinic/client v0.0.0-20250620124207-97640792dd28 h1:lwZK
 github.com/tidepool-org/clinic/client v0.0.0-20250620124207-97640792dd28/go.mod h1:F13LyaGiR5Ua7+1B8MjbPEW+jqcnFm+5YqsQPv+kmdE=
 github.com/tidepool-org/clinic/redox_models v0.0.0-20250604035007-1aa5b79109b4 h1:2tAEp84UA3jgF/CUl29XfznhoTmJCip7dODSr2af0fY=
 github.com/tidepool-org/clinic/redox_models v0.0.0-20250604035007-1aa5b79109b4/go.mod h1:bQ9DZxk015RhmGG1tR6jRScP9KxyHvS8tzPbVtr82DE=
-github.com/tidepool-org/go-common v0.12.3-0.20250604040229-ade89b59e5db h1:F2DS4kqgKYqu58rvS1KYd1WDIy+oH8+wafeW0Ec9BYQ=
-github.com/tidepool-org/go-common v0.12.3-0.20250604040229-ade89b59e5db/go.mod h1:v93bMGDHiHcltQY5s7LYTTEe3u9CiGWqBFKah6C0650=
+github.com/tidepool-org/go-common v0.12.3-0.20250714145502-f6b9f7ad36fe h1:oVgAtrhHXwTA0b5dA0RO1zEXPUlAfziVXfaYnqS0MYI=
+github.com/tidepool-org/go-common v0.12.3-0.20250714145502-f6b9f7ad36fe/go.mod h1:v93bMGDHiHcltQY5s7LYTTEe3u9CiGWqBFKah6C0650=
 github.com/tidepool-org/hydrophone/client v0.0.0-20250317164837-a8cd51fd6677 h1:P3C1YTvLHu7NFHOeh6NDPo5ieVXcF9a+SY4FTToR8B4=
 github.com/tidepool-org/hydrophone/client v0.0.0-20250317164837-a8cd51fd6677/go.mod h1:gon+x+jAh8DZZ2hD23fBWqrYwOizVSwIBbxEsuXCbZ4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/vendor/github.com/tidepool-org/go-common/clients/auth.go
+++ b/vendor/github.com/tidepool-org/go-common/clients/auth.go
@@ -235,7 +235,7 @@ func (client *AuthClient) DeleteRestrictedToken(tokenID string, token string) er
 	defer res.Body.Close()
 
 	switch res.StatusCode {
-	case http.StatusNoContent:
+	case http.StatusOK:
 		return nil
 	default:
 		return &status.StatusError{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -207,7 +207,7 @@ github.com/tidepool-org/clinic/client
 # github.com/tidepool-org/clinic/redox_models v0.0.0-20250604035007-1aa5b79109b4
 ## explicit; go 1.22
 github.com/tidepool-org/clinic/redox_models
-# github.com/tidepool-org/go-common v0.12.3-0.20250604040229-ade89b59e5db
+# github.com/tidepool-org/go-common v0.12.3-0.20250714145502-f6b9f7ad36fe
 ## explicit; go 1.24.1
 github.com/tidepool-org/go-common/clients
 github.com/tidepool-org/go-common/clients/disc


### PR DESCRIPTION
The service is stuck trying to delete a token because  the auth client in go-common incorrectly expects a 204 response instead of 200. 
```
200 Unknown response code from service[http://auth:9222/v1/restricted_tokens/...]
```

This PR updates the go-common dependency to include the fix in https://github.com/tidepool-org/go-common/pull/80