### PR TITLE
[BACK-3700] Increase Redox message processing timeout ot 3 minutes and reduce the number of retries to 3

### DIFF
--- a/cdc/retry.go
+++ b/cdc/retry.go
@@ -1,10 +1,11 @@
 package cdc
 
 import (
+	"time"
+
 	"github.com/IBM/sarama"
 	"github.com/avast/retry-go"
 	"github.com/tidepool-org/go-common/events"
-	"time"
 )
 
 var (
@@ -13,19 +14,29 @@ var (
 	DefaultDelayType = retry.FixedDelay
 )
 
+type RetryOptions struct {
+	Attempts  uint
+	Delay     time.Duration
+	DelayType retry.DelayTypeFunc
+}
+
 type RetryingConsumer struct {
-	attempts  uint
-	delay     time.Duration
-	delayType retry.DelayTypeFunc
-	delegate  events.MessageConsumer
+	opts     RetryOptions
+	delegate events.MessageConsumer
 }
 
 func NewRetryingConsumer(delegate events.MessageConsumer) events.MessageConsumer {
+	return NewRetryingConsumerWithOpts(delegate, RetryOptions{
+		Attempts:  DefaultAttempts,
+		Delay:     DefaultDelay,
+		DelayType: DefaultDelayType,
+	})
+}
+
+func NewRetryingConsumerWithOpts(delegate events.MessageConsumer, opts RetryOptions) events.MessageConsumer {
 	return &RetryingConsumer{
-		attempts:  DefaultAttempts,
-		delay:     DefaultDelay,
-		delayType: DefaultDelayType,
-		delegate:  delegate,
+		opts:     opts,
+		delegate: delegate,
 	}
 }
 
@@ -37,8 +48,8 @@ func (r *RetryingConsumer) HandleKafkaMessage(cm *sarama.ConsumerMessage) error 
 	retryFn := func() error { return r.delegate.HandleKafkaMessage(cm) }
 	return retry.Do(
 		retryFn,
-		retry.Attempts(r.attempts),
-		retry.Delay(r.delay),
-		retry.DelayType(r.delayType),
+		retry.Attempts(r.opts.Attempts),
+		retry.Delay(r.opts.Delay),
+		retry.DelayType(r.opts.DelayType),
 	)
 }

--- a/redox/consumer_message.go
+++ b/redox/consumer_message.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/IBM/sarama"
+	"github.com/avast/retry-go"
 	"github.com/tidepool-org/clinic-worker/cdc"
 	models "github.com/tidepool-org/clinic/redox_models"
 	"github.com/tidepool-org/go-common/events"
@@ -54,7 +55,7 @@ func NewRedoxMessageConsumer(p MessageCDCConsumerParams) events.ConsumerFactory 
 		if err != nil {
 			return nil, err
 		}
-		return cdc.NewRetryingConsumer(delegate), nil
+		return cdc.NewRetryingConsumerWithOpts(delegate, retryOptions), nil
 	}
 }
 

--- a/redox/consumer_message.go
+++ b/redox/consumer_message.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/IBM/sarama"
-	"github.com/avast/retry-go"
 	"github.com/tidepool-org/clinic-worker/cdc"
 	models "github.com/tidepool-org/clinic/redox_models"
 	"github.com/tidepool-org/go-common/events"

--- a/redox/consumer_scheduled.go
+++ b/redox/consumer_scheduled.go
@@ -2,6 +2,7 @@ package redox
 
 import (
 	"context"
+
 	"github.com/IBM/sarama"
 	"github.com/tidepool-org/clinic-worker/cdc"
 	"github.com/tidepool-org/go-common/events"
@@ -52,7 +53,7 @@ func NewScheduledSummaryAndReportsConsumer(p ScheduledSummaryAndReportsCDCConsum
 		if err != nil {
 			return nil, err
 		}
-		return cdc.NewRetryingConsumer(delegate), nil
+		return cdc.NewRetryingConsumerWithOpts(delegate, retryOptions), nil
 	}
 }
 

--- a/redox/module.go
+++ b/redox/module.go
@@ -1,10 +1,13 @@
 package redox
 
 import (
+	"time"
+
+	"github.com/avast/retry-go"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/tidepool-org/clinic-worker/cdc"
 	"github.com/tidepool-org/clinic-worker/report"
 	"go.uber.org/fx"
-	"time"
 )
 
 var Module = fx.Provide(
@@ -24,8 +27,14 @@ var Module = fx.Provide(
 )
 
 const (
-	defaultTimeout = 60 * time.Second
+	defaultTimeout = 180 * time.Second
 )
+
+var retryOptions = cdc.RetryOptions{
+	Attempts:  3,
+	Delay:     15 * time.Second,
+	DelayType: retry.FixedDelay,
+}
 
 type ModuleConfig struct {
 	Enabled bool `envconfig:"TIDEPOOL_REDOX_ENABLED" default:"false"`


### PR DESCRIPTION
Sometimes the report generation and uploads take more than a minute (the current timeout). Increasing this to 3 minutes should allow generation of reports for users with DIY, TP Mobile and Dexcom data. To reduce the number of manual interventions there's a new retry limit of 3, as we usually just skip over failing messages on the redox topics.